### PR TITLE
Added argument to start a specific profile with HBRelog

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -166,6 +166,8 @@ namespace HighVoltz.HBRelog
             Log.Write("\t{0,-30} {1}", "Minimize Hb On Startup:", HbRelogManager.Settings.MinimizeHbOnStart);
 			Log.Write("\t{0,-30} {1}", "Set GameWindow Title:", HbRelogManager.Settings.SetGameWindowTitle);
             Log.Write("\t{0,-30} {1}", "Wow Start Delay:", HbRelogManager.Settings.WowDelay);
+            Log.Write("\t{0,-30} {1}", "Profiles to start:", string.Join(",", HbRelogManager.Settings.ProfilesToStart));
+
             // if autostart is on then start all enabled acounts
             if (HbRelogManager.Settings.AutoStart)
             {
@@ -173,6 +175,20 @@ namespace HighVoltz.HBRelog
                 {
                     if (character.Settings.IsEnabled)
                         character.Start();
+                }
+            }
+
+            if (HbRelogManager.Settings.ProfilesToStart != null && HbRelogManager.Settings.ProfilesToStart.Any())
+            {
+                foreach (var profileToStart in HbRelogManager.Settings.ProfilesToStart)
+                {
+                    foreach (CharacterProfile item in AccountGrid.Items)
+                    {
+                        if (item.Settings.ProfileName.Equals(profileToStart, StringComparison.CurrentCultureIgnoreCase))
+                            item.Start();
+                    }
+
+                    Log.Write("\t{0,-30} {1}", "Couldn't start:", profileToStart);
                 }
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -48,6 +48,12 @@ namespace HighVoltz.HBRelog
                         HbRelogManager.Settings.WowDelay = GetCmdLineArgVal<int>(CmdLineArgs["WOWDELAY"]);
                     if (CmdLineArgs.ContainsKey("HBDELAY"))
                         HbRelogManager.Settings.HBDelay = GetCmdLineArgVal<int>(CmdLineArgs["HBDELAY"]);
+                    if (CmdLineArgs.ContainsKey("PROFILESTOSTART"))
+                    {
+                        var rawProfilesToStart = GetCmdLineArgVal<string>(CmdLineArgs["PROFILESTOSTART"]);
+                        var profilesToStart = rawProfilesToStart.Trim().Split(';', '|', ',');
+                        HbRelogManager.Settings.ProfilesToStart = profilesToStart;
+                    }
 
                     var app = new Application();
                     Window window = new MainWindow();

--- a/Settings/GlobalSettings.cs
+++ b/Settings/GlobalSettings.cs
@@ -56,6 +56,7 @@ namespace HighVoltz.HBRelog.Settings
 		private bool _useDarkStyle;
 		private bool _setGameWindowTitle;
         private int _wowDelay;
+        private string[] _profilesToStart;
 
         private GlobalSettings()
         {
@@ -80,15 +81,21 @@ namespace HighVoltz.HBRelog.Settings
         public ObservableCollection<CharacterProfile> CharacterProfiles { get; private set; }
         // Automatically start all enabled profiles on start
 
-	    public bool AutoStart
-	    {
-		    get { return _autoStart; }
-		    set { NotifyPropertyChanged(ref _autoStart, ref value, nameof(AutoStart)); }
-	    }
+        public bool AutoStart
+        {
+            get { return _autoStart; }
+            set { NotifyPropertyChanged(ref _autoStart, ref value, nameof(AutoStart)); }
+        }
+
+        public string[] ProfilesToStart
+        {
+            get { return _profilesToStart; }
+            set { NotifyPropertyChanged(ref _profilesToStart, ref value, nameof(ProfilesToStart)); }
+        }
 
         // delay in seconds between starting multiple Wow instance
 
-	    public int WowDelay
+        public int WowDelay
 	    {
 		    get { return _wowDelay; }
 		    set { NotifyPropertyChanged(ref _wowDelay, ref value, nameof(WowDelay)); }


### PR DESCRIPTION
Hi,

I've added an argument PROFILESTOSTART to start HBRelog and launch a specific profile.
I want to use the Windows task scheduler to start HBRelog and launch a profile at a specific time.